### PR TITLE
feat: UM-35 white and black as token color in neutral palette

### DIFF
--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -1,11 +1,22 @@
-import type { ColorPalette, ColorShade } from '../types/color'
+import type {
+  ColorPalette,
+  ColorShade,
+  ExtendedColorPalette,
+  ExtendedColorShade,
+} from '../types/color'
 
 export const colors: Record<
   ColorPalette,
   {
     [key in ColorShade]: string
   }
-> = {
+> &
+  Record<
+    ExtendedColorPalette,
+    {
+      [key in ExtendedColorShade]: string
+    }
+  > = {
   slate: {
     50: '#f8fafc',
     100: '#f1f5f9',
@@ -46,6 +57,7 @@ export const colors: Record<
     950: '#09090b',
   },
   neutral: {
+    0: '#ffffff',
     50: '#fafafa',
     100: '#f5f5f5',
     200: '#e5e5e5',
@@ -57,6 +69,7 @@ export const colors: Record<
     800: '#262626',
     900: '#171717',
     950: '#0a0a0a',
+    1000: '#000000',
   },
   stone: {
     50: '#fafaf9',

--- a/src/types/color.ts
+++ b/src/types/color.ts
@@ -27,6 +27,21 @@ export type HexColor<T extends string> =
         : never
       : never
 
+export type ExtendedColorShade =
+  | 0
+  | 50
+  | 100
+  | 200
+  | 300
+  | 400
+  | 500
+  | 600
+  | 700
+  | 800
+  | 900
+  | 950
+  | 1000
+
 export type ColorShade =
   | 50
   | 100
@@ -40,11 +55,12 @@ export type ColorShade =
   | 900
   | 950
 
+export type ExtendedColorPalette = 'neutral'
+
 export type ColorPalette =
   | 'slate'
   | 'gray'
   | 'zinc'
-  | 'neutral'
   | 'stone'
   | 'red'
   | 'orange'
@@ -64,6 +80,8 @@ export type ColorPalette =
   | 'pink'
   | 'rose'
 
-export type TokenColor = `${ColorPalette}-${ColorShade}`
+export type TokenColor =
+  | `${ExtendedColorPalette}-${ExtendedColorShade}`
+  | `${ColorPalette}-${ColorShade}`
 
 export type Color<T extends string = string> = TokenColor | HexColor<T>


### PR DESCRIPTION
[UM-35 white and black color as token](https://github.com/users/Dhitpl/projects/1?pane=issue&itemId=80360446)

## What was the task?
Add black and white as token color to neutral palette

## What has been changed?
- updated colors map with neutral-0 and neutral-1000,
- token colors types to accept extended shades

## Checklist

- [x] The code has been cleaned up (unused imports, `console.log`s, etc.).
- [x] The PR has its assignee(s) selected.
- [x] The PR has its reviewer(s) selected.
- [x] The PR’s title is compliant with our `commit-lint` configuration.
