### PR TITLE
refactor: UM-54 util | getSizbyByBreakpoint to be shared

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
     "magnetyczny",
     "nextjs",
     "Parens",
+    "plusplus",
     "tailwindcss",
     "typecheck",
     "uchwyt",

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -4,11 +4,11 @@ import type { Color } from '~/types'
 
 import { useBreakpoint } from '~/hooks'
 
-import { cn, getColor } from '~/utils'
+import { cn, getColor, getSizeByBreakpoint } from '~/utils'
 
 import { defaultColor } from './icon.const'
 import { Custom, Lucide, Size } from './icon.types'
-import { getIconComponent, getSizeByBreakpoint } from './icon.utils'
+import { getIconComponent } from './icon.utils'
 
 export type IconProps<T extends string = string> = {
   size?: Size

--- a/src/components/icon/icon.utils.tsx
+++ b/src/components/icon/icon.utils.tsx
@@ -1,9 +1,7 @@
 import { convertCaseStyle } from '~/utils'
 
-import { type Breakpoint, breakpoints } from '~/styles'
-
 import { customIcons, lucideIcons } from './icon.const'
-import type { Custom, Lucide, Size } from './icon.types'
+import type { Custom, Lucide } from './icon.types'
 
 type GetIconComponentProps = Lucide | Custom
 
@@ -28,36 +26,4 @@ export const getIconComponent = (props: GetIconComponentProps) => {
   }
 
   return () => null
-}
-
-type GetSizeByBreakpointProps = {
-  size?: Size
-  breakpoint: Breakpoint
-}
-
-/**
- * Gets the size of an element based on the current breakpoint and the provided size object.
- *
- * @param {GetSizeByBreakpointProps} props - The size and breakpoint information.
- * @returns The size for the given breakpoint or a fallback value.
- */
-export const getSizeByBreakpoint = ({
-  size,
-  breakpoint,
-}: GetSizeByBreakpointProps) => {
-  if (typeof size === 'number' || size === undefined) {
-    return size
-  }
-
-  const breakpointsOrder = Object.keys(breakpoints) as Breakpoint[]
-  const breakpointIndex = breakpointsOrder.indexOf(breakpoint)
-
-  if (breakpointIndex === -1) return undefined
-
-  const closestSize = breakpointsOrder
-    .slice(0, breakpointIndex + 1)
-    .reverse()
-    .find(bp => size[bp] !== undefined)
-
-  return closestSize !== undefined ? size[closestSize] : undefined
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './color'
 export * from './convert-case-style'
 export * from './page'
+export * from './size'

--- a/src/types/size.ts
+++ b/src/types/size.ts
@@ -1,0 +1,5 @@
+import type { Breakpoint } from '~/styles'
+
+type SizeValue = number
+
+export type Size = SizeValue | { [key in Breakpoint]?: SizeValue }

--- a/src/utils/get-size-by-breakpoint/get-size-by-breakpoint.test.ts
+++ b/src/utils/get-size-by-breakpoint/get-size-by-breakpoint.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { Breakpoint } from '~/styles'
 
-import { getSizeByBreakpoint } from './icon.utils'
+import { getSizeByBreakpoint } from './get-size-by-breakpoint'
 
 describe('getSizeByBreakpoint', () => {
   it('should return the correct size for a given breakpoint', () => {

--- a/src/utils/get-size-by-breakpoint/get-size-by-breakpoint.ts
+++ b/src/utils/get-size-by-breakpoint/get-size-by-breakpoint.ts
@@ -1,0 +1,35 @@
+import type { Size } from '~/types'
+
+import { type Breakpoint, breakpoints } from '~/styles'
+
+type GetSizeByBreakpointProps = {
+  size?: Size
+  breakpoint: Breakpoint
+}
+
+/**
+ * Gets the size of an element based on the current breakpoint and the provided size object.
+ *
+ * @param {GetSizeByBreakpointProps} props - The size and breakpoint information.
+ * @returns The size for the given breakpoint or a fallback value.
+ */
+export const getSizeByBreakpoint = ({
+  size,
+  breakpoint,
+}: GetSizeByBreakpointProps) => {
+  if (typeof size === 'number' || size === undefined) {
+    return size
+  }
+
+  const breakpointsOrder = Object.keys(breakpoints) as Breakpoint[]
+  const breakpointIndex = breakpointsOrder.indexOf(breakpoint)
+
+  if (breakpointIndex === -1) return undefined
+
+  const closestSize = breakpointsOrder
+    .slice(0, breakpointIndex + 1)
+    .reverse()
+    .find(bp => size[bp] !== undefined)
+
+  return closestSize !== undefined ? size[closestSize] : undefined
+}

--- a/src/utils/get-size-by-breakpoint/get-size-by-breakpoint.ts
+++ b/src/utils/get-size-by-breakpoint/get-size-by-breakpoint.ts
@@ -26,10 +26,14 @@ export const getSizeByBreakpoint = ({
 
   if (breakpointIndex === -1) return undefined
 
-  const closestSize = breakpointsOrder
-    .slice(0, breakpointIndex + 1)
-    .reverse()
-    .find(bp => size[bp] !== undefined)
+  // eslint-disable-next-line no-plusplus
+  for (let i = breakpointIndex; i >= 0; i--) {
+    const bp = breakpointsOrder[i]
 
-  return closestSize !== undefined ? size[closestSize] : undefined
+    if (size[bp] !== undefined) {
+      return size[bp]
+    }
+  }
+
+  return undefined
 }

--- a/src/utils/get-size-by-breakpoint/index.ts
+++ b/src/utils/get-size-by-breakpoint/index.ts
@@ -1,0 +1,1 @@
+export * from './get-size-by-breakpoint'

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './cn'
 export * from './convert-case-style'
 export * from './get-color'
+export * from './get-size-by-breakpoint'


### PR DESCRIPTION
[UM-54 util | getSizbyByBreakpoint to be shared](https://github.com/users/Dhitpl/projects/1?pane=issue&itemId=82258382)

## What was the task?
Move util `getSizbyByBreakpoint` from `/components/icon/icon.utils.ts` to `/utils/getSizbyByBreakpoint/getSizbyByBreakpoint.ts`

## What has been changed?
- removed from `icon.utils`,
- replaced imports,
- move size type into `/types/size.ts`

## Checklist
- [x] The code has been cleaned up (unused imports, `console.log`s, etc.).
- [x] The PR has its assignee(s) selected.
- [x] The PR has its reviewer(s) selected.
- [x] The PR’s title is compliant with our `commit-lint` configuration.
