### PR TITLE
feat: UM-52 util | deep merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "next-intl": "^3.14.0",
     "react": "^18",
     "react-dom": "^18",
+    "react-hook-form": "^7.53.0",
     "tailwind-merge": "^2.3.0",
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ dependencies:
   react-dom:
     specifier: ^18
     version: 18.3.1(react@18.3.1)
+  react-hook-form:
+    specifier: ^7.53.0
+    version: 7.53.0(react@18.3.1)
   tailwind-merge:
     specifier: ^2.3.0
     version: 2.5.2
@@ -8257,6 +8260,15 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
       react-is: 18.1.0
     dev: true
+
+  /react-hook-form@7.53.0(react@18.3.1):
+    resolution: {integrity: sha512-M1n3HhqCww6S2hxLxciEXy2oISPnAzxY7gvwVPrtlczTM/1dDadXgUxDpHMrMTblDOcm/AXtXxHwZ3jpg1mqKQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+    dependencies:
+      react: 18.3.1
+    dev: false
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}

--- a/src/utils/deep-merge/deep-merge.test.ts
+++ b/src/utils/deep-merge/deep-merge.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest'
+
+import { deepMerge } from './deep-merge'
+
+describe('deepMerge', () => {
+  it('should deeply merge two objects', () => {
+    const base = {
+      a: 1,
+      b: {
+        c: 2,
+        d: {
+          e: 3,
+          f: 4,
+        },
+      },
+      g: 5,
+    }
+
+    const partial = {
+      b: {
+        c: 20,
+      },
+    }
+
+    const expected = {
+      a: 1,
+      b: {
+        c: 20,
+        d: {
+          e: 3,
+          f: 4,
+        },
+      },
+      g: 5,
+    }
+
+    const result = deepMerge(base, partial)
+    expect(result).toEqual(expected)
+  })
+
+  it('should overwrite top-level properties', () => {
+    const base = {
+      a: 1,
+      b: {
+        c: 2,
+      },
+    }
+
+    const partial = {
+      a: 100,
+    }
+
+    const expected = {
+      a: 100,
+      b: {
+        c: 2,
+      },
+    }
+
+    const result = deepMerge(base, partial)
+    expect(result).toEqual(expected)
+  })
+
+  it('should handle nested undefined properties', () => {
+    const base = {
+      a: 1,
+      b: {
+        c: 2,
+        d: {
+          e: 3,
+        },
+      },
+    }
+
+    const partial = {
+      b: {
+        d: undefined,
+      },
+    }
+
+    const expected = {
+      a: 1,
+      b: {
+        c: 2,
+        d: undefined,
+      },
+    }
+
+    const result = deepMerge(base, partial)
+    expect(result).toEqual(expected)
+  })
+
+  it('should work with empty partial object', () => {
+    const base = {
+      a: 1,
+      b: {
+        c: 2,
+      },
+    }
+
+    const partial = {}
+
+    const expected = {
+      a: 1,
+      b: {
+        c: 2,
+      },
+    }
+
+    const result = deepMerge(base, partial)
+    expect(result).toEqual(expected)
+  })
+
+  it('should handle arrays as values without merging them', () => {
+    const base = {
+      a: [1, 2, 3],
+      b: {
+        c: [4, 5, 6],
+      },
+    }
+
+    const partial = {
+      b: {
+        c: [7, 8, 9],
+      },
+    }
+
+    const expected = {
+      a: [1, 2, 3],
+      b: {
+        c: [7, 8, 9],
+      },
+    }
+
+    const result = deepMerge(base, partial)
+    expect(result).toEqual(expected)
+  })
+
+  it('should add new properties from the partial object', () => {
+    const base = {
+      a: 1,
+      b: {
+        c: 2,
+      },
+    }
+
+    const partial = {
+      b: {
+        d: 3,
+      },
+      e: 4,
+    }
+
+    const expected = {
+      a: 1,
+      b: {
+        c: 2,
+        d: 3,
+      },
+      e: 4,
+    }
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    const result = deepMerge(base, partial)
+    expect(result).toEqual(expected)
+  })
+
+  it('should return the base object if partial is undefined', () => {
+    const base = {
+      a: 1,
+      b: {
+        c: 2,
+      },
+    }
+
+    const partial = undefined
+
+    const expected = {
+      a: 1,
+      b: {
+        c: 2,
+      },
+    }
+
+    const result = deepMerge(base, partial)
+    expect(result).toEqual(expected)
+  })
+})

--- a/src/utils/deep-merge/deep-merge.ts
+++ b/src/utils/deep-merge/deep-merge.ts
@@ -1,0 +1,45 @@
+import type { DeepPartial } from 'react-hook-form'
+
+/**
+ * Deeply merges two objects. The `partial` object will be merged into the `base` object.
+ * If a property in `partial` is an object, it will be recursively merged with the corresponding property in `base`.
+ * If a property in `partial` is not an object, it will overwrite the corresponding property in `base`.
+ *
+ * @template T - The type of the objects being merged.
+ * @param {T} base - The base object that will be merged into.
+ * @param {DeepPartial<T>} [partial={}] - The partial object that will be merged into the base object.
+ * @returns {T} - The merged object.
+ *
+ * @example
+ * const base = { a: 1, b: { c: 2 } };
+ * const partial = { b: { c: 3 }, a: 4 };
+ * const result = deepMerge(base, partial);
+ * console.log(result); // { a: 4, b: { c: 3 } }
+ */
+export function deepMerge<T>(
+  base: T,
+  partial: DeepPartial<T> = {} as DeepPartial<T>,
+): T {
+  const result = { ...base }
+
+  Object.keys(partial).forEach(key => {
+    const typedKey = key as keyof T
+
+    if (key in partial) {
+      if (
+        typeof partial[typedKey] === 'object' &&
+        partial[typedKey] !== null &&
+        !Array.isArray(partial[typedKey])
+      ) {
+        result[typedKey] = deepMerge(
+          result[typedKey],
+          partial[typedKey] as DeepPartial<T[keyof T]>,
+        )
+      } else {
+        result[typedKey] = partial[typedKey] as T[keyof T]
+      }
+    }
+  })
+
+  return result
+}

--- a/src/utils/deep-merge/deep-merge.ts
+++ b/src/utils/deep-merge/deep-merge.ts
@@ -25,19 +25,17 @@ export function deepMerge<T>(
   Object.keys(partial).forEach(key => {
     const typedKey = key as keyof T
 
-    if (key in partial) {
-      if (
-        typeof partial[typedKey] === 'object' &&
-        partial[typedKey] !== null &&
-        !Array.isArray(partial[typedKey])
-      ) {
-        result[typedKey] = deepMerge(
-          result[typedKey],
-          partial[typedKey] as DeepPartial<T[keyof T]>,
-        )
-      } else {
-        result[typedKey] = partial[typedKey] as T[keyof T]
-      }
+    if (
+      typeof partial[typedKey] === 'object' &&
+      partial[typedKey] !== null &&
+      !Array.isArray(partial[typedKey])
+    ) {
+      result[typedKey] = deepMerge(
+        result[typedKey],
+        partial[typedKey] as DeepPartial<T[keyof T]>,
+      )
+    } else {
+      result[typedKey] = partial[typedKey] as T[keyof T]
     }
   })
 

--- a/src/utils/deep-merge/index.ts
+++ b/src/utils/deep-merge/index.ts
@@ -1,0 +1,1 @@
+export * from './deep-merge'

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './cn'
 export * from './convert-case-style'
+export * from './deep-merge'
 export * from './get-color'


### PR DESCRIPTION
[UM-52 util | deep merge](https://github.com/users/Dhitpl/projects/1?pane=issue&itemId=82258320)

## What was the task?
Create util for deep merging two objects

## What has been changed?
- installed `react-hook-form` (we planned use it on the future for handling forms, and this library export DeepPartial type),
- created deep merge util,
- created test

## Checklist
- [x] The code has been cleaned up (unused imports, `console.log`s, etc.).
- [x] The PR has its assignee(s) selected.
- [x] The PR has its reviewer(s) selected.
- [x] The PR’s title is compliant with our `commit-lint` configuration.
